### PR TITLE
add controllers/internals to nav list

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - controllers/relations.md
   - controllers/testing.md
   - controllers/security.md
+  - controllers/internals.md
 
   #- comunity.md
   #- proposal-process.md


### PR DESCRIPTION
This page is somewhat hidden: only linked from architecture and reconciler. Not sure if that's intended?