### PR TITLE
Add a doc about how to re-use reconciler/controller logic

### DIFF
--- a/docs/controllers/generics.md
+++ b/docs/controllers/generics.md
@@ -50,7 +50,7 @@ For information about the resource we rely on the generic [Resource] and [Resour
 These reconcilers can be hooked up to a `Controller<K>` with another possibly generic fn.
 
 ```rust
-async fn run_controller<K>(client: Client) -> Result<(), Infallible>
+async fn run_controller<K>(client: Client)
 where
     K: Resource<Scope = NamespaceResourceScope, DynamicType = ()>
         + Clone
@@ -83,7 +83,6 @@ where
         .await;
 
     warn!("controller for {kind} shutdown");
-    Ok(())
 }
 ```
 
@@ -93,20 +92,17 @@ We can start and control the lifecycle of all the controllers with a [tokio::try
 
 ```rust
 pub async fn run_all_controllers(client: Client) {
-    if let Err(e) = tokio::try_join!(
+    let _ = tokio::join!(
         run_controller::<Deployment>(client.clone()),
         run_controller::<DaemonSet>(client.clone()),
         run_controller::<StatefulSet>(client.clone()),
         run_controller::<CronJob>(client.clone()),
-    ) {
-        error!("run_controller failed: {e:?}");
-        unreachable!("run_controller is infallible");
-    }
+    );
     info!("controllers all exited");
 }
 ```
 
-This returns when **all** controller fns return `Ok(())`. This only happens once [shutdown_on_signal] has propagated through all the controllers because the `run_controller` fn is here [Infallible].
+This returns when **all** controller fns return. This only happens once [shutdown_on_signal] has propagated through all the controllers because the `run_controller` fn is here infallible.
 
 
 --8<-- "includes/abbreviations.md"

--- a/docs/controllers/generics.md
+++ b/docs/controllers/generics.md
@@ -1,0 +1,113 @@
+# Generics
+
+This chapter contains tips and tricks for re-using generic reconcilers.
+
+## Generic Reconcilers
+It is possible to create generic reconcilers by abstracing away the underlying type by using either [DynamicObject] or [PartialObjectMeta].
+
+This is a useful technique for controllers that need to do _the same thing_ to a bunch of resources, like for instance adding consistent labels / annotations.
+
+### PartialObjectMeta
+
+This is the easiest and cheapest way to create a generic reconciler because it still retains type information, and you do not have to devolve into a fully dynamic api.
+
+You can create generic reconcilers:
+
+```rust
+pub async fn reconcile<K>(obj: Arc<PartialObjectMeta<K>>, ctx: Arc<Context>)
+-> Result<Action>
+where
+    K: Resource<Scope = NamespaceResourceScope, DynamicType = ()>
+        + Clone
+        + DeserializeOwned
+        + Debug,
+{
+    let kind = K::kind(&()).to_string();
+    let ns = obj.namespace().unwrap();
+    let object_name = obj.name_any();
+    let api: Api<PartialObjectMeta<K>> = Api::namespaced(ctx.client, &ns);
+
+    // example work; apply some labels to the object
+    let patch: Patch<serde_json::Value> = get_standard_labels_for(&obj)?;
+    let serverside = PatchParams::apply("labeler");
+    api.patch(&object_name, &serverside, &patch).await?;
+
+    Ok(Action::requeue(Duration::from_secs(5 * 60)))
+}
+```
+
+The generic constraints on the associated type of the [Resource] here means this is a __namespaced__ resource (hence the unwrap). You could remove this bound (or change it for a cluster scoped only bound), but then you could not unwrap.
+
+The `DynamicType = ()` constraint is to indicate that this is one of the normal statically generated api types that we have api information for at the type level (i.e. they come from `k8s-openapi`).
+
+For information about the resource we rely on the generic [Resource] and [ResourceExt] traits which is implemented by [PartialObjectMeta].
+
+!!! note "Diverging Logic"
+
+    You will only get access to metadata of the object doing this. This can be mitigated by doing a `match` on `kind` and creating a more specific `Api<K>` inside a match arm.
+
+
+These reconcilers can be hooked up to a `Controller<K>` with another possibly generic fn.
+
+```rust
+async fn run_controller<K>(client: Client) -> Result<(), Infallible>
+where
+    K: Resource<Scope = NamespaceResourceScope, DynamicType = ()>
+        + Clone
+        + DeserializeOwned
+        + Debug
+        + Sync
+        + Send
+        + 'static,
+{
+    let kind = K::kind(&()).to_string();
+    tracing::info!("Starting controller for {kind}");
+
+    let api = Api::<K>::all(client.clone());
+    let (reader, writer) = reflector::store();
+
+    // controller main stream from metadata_watcher
+    let stream = metadata_watcher(api, watcher::Config::default())
+        .default_backoff()
+        .modify(|x| {
+            x.managed_fields_mut().clear(); // ResourceExt pruning
+        })
+        .reflect(writer)
+        .applied_objects()
+        .predicate_filter(predicates::generation);
+
+    Controller::for_stream(stream, reader)
+        .shutdown_on_signal()
+        .run(reconcile, error_policy, Arc::new(Context::new(client)))
+        .for_each(|_| futures::future::ready(()))
+        .await;
+
+    warn!("controller for {kind} shutdown");
+    Ok(())
+}
+```
+
+This example assumes no [[relations]] between the main controller [[object]], so that each controller can be started in isolation without worrying about inefficiencies in stream-reuse (see [[streams]]). It also relies on [WatchStreamExt] + [metadata_watcher] to apply a consistent stream setup, pruning, and predicates (see [[optimization]]).
+
+We can start and control the lifecycle of all the controllers with a [tokio::try_join!]:
+
+```rust
+pub async fn run_all_controllers(client: Client) {
+    if let Err(e) = tokio::try_join!(
+        run_controller::<Deployment>(client.clone()),
+        run_controller::<DaemonSet>(client.clone()),
+        run_controller::<StatefulSet>(client.clone()),
+        run_controller::<CronJob>(client.clone()),
+    ) {
+        error!("run_controller failed: {e:?}");
+        unreachable!("run_controller is infallible");
+    }
+    info!("controllers all exited");
+}
+```
+
+This returns when **all** controller fns return `Ok(())`. This only happens once [shutdown_on_signal] has propagated through all the controllers because the `run_controller` fn is here [Infallible].
+
+
+--8<-- "includes/abbreviations.md"
+--8<-- "includes/links.md"

--- a/docs/controllers/generics.md
+++ b/docs/controllers/generics.md
@@ -47,7 +47,7 @@ For information about the resource we rely on the generic [Resource] and [Resour
     You will only get access to metadata of the object doing this. This can be mitigated by doing a `match` on `kind` and creating a more specific `Api<K>` inside a match arm.
 
 
-These reconcilers can be hooked up to a `Controller<K>` with another possibly generic fn.
+This reconciler can be hooked up to infallabily start a `Controller<K>` in a generic way:
 
 ```rust
 async fn run_controller<K>(client: Client)
@@ -85,9 +85,9 @@ where
 }
 ```
 
-This example assumes no [[relations]] between the main controller [[object]], so that each controller can be started in isolation without worrying about inefficiencies in stream-reuse (see [[streams]]). It also relies on [WatchStreamExt] + [metadata_watcher] to apply a consistent stream setup with pruning (see [[optimization]]).
+This example assumes no [[relations]] between the main controller [[object]], so that each controller can be started in isolation without worrying about inefficiencies in [[streams]] usage. It uses [metadata_watcher] to provide a consistent input stream of `PartialObjectMeta<K>` with pruning ([[optimization#pruning-fields]]) and [Store] management through [WatchStreamExt].
 
-We can start and control the lifecycle of all the controllers with a [tokio::try_join!]:
+We can start and control the lifecycle of all the controllers with a [tokio::join!]:
 
 ```rust
 pub async fn run_all_controllers(client: Client) {
@@ -101,7 +101,7 @@ pub async fn run_all_controllers(client: Client) {
 }
 ```
 
-This returns when **all** controller fns return. This only happens once [shutdown_on_signal] has propagated through all the controllers because the `run_controller` fn is here infallible.
+This returns when **all** controller fns return. This happens once [shutdown_on_signal] has safely propagated through all the controllers.
 
 
 --8<-- "includes/abbreviations.md"

--- a/docs/controllers/generics.md
+++ b/docs/controllers/generics.md
@@ -73,8 +73,7 @@ where
             x.managed_fields_mut().clear(); // ResourceExt pruning
         })
         .reflect(writer)
-        .applied_objects()
-        .predicate_filter(predicates::generation);
+        .applied_objects();
 
     Controller::for_stream(stream, reader)
         .shutdown_on_signal()
@@ -86,7 +85,7 @@ where
 }
 ```
 
-This example assumes no [[relations]] between the main controller [[object]], so that each controller can be started in isolation without worrying about inefficiencies in stream-reuse (see [[streams]]). It also relies on [WatchStreamExt] + [metadata_watcher] to apply a consistent stream setup, pruning, and predicates (see [[optimization]]).
+This example assumes no [[relations]] between the main controller [[object]], so that each controller can be started in isolation without worrying about inefficiencies in stream-reuse (see [[streams]]). It also relies on [WatchStreamExt] + [metadata_watcher] to apply a consistent stream setup with pruning (see [[optimization]]).
 
 We can start and control the lifecycle of all the controllers with a [tokio::try_join!]:
 

--- a/includes/links.md
+++ b/includes/links.md
@@ -44,6 +44,7 @@
 [merge_crds]: https://docs.rs/kube/latest/kube/core/crd/v1/fn.merge_crds.html
 [shutdown_on_signal]: https://docs.rs/kube/latest/kube/runtime/struct.Controller.html#method.shutdown_on_signal
 [tokio::try_join!]: https://docs.rs/tokio/latest/tokio/macro.try_join.html
+[tokio::join!]: https://docs.rs/tokio/latest/tokio/macro.join.html
 [kube]: https://crates.io/crates/kube
 [kopium]: https://github.com/kube-rs/kopium
 [controller-rs]: https://github.com/kube-rs/controller-rs

--- a/includes/links.md
+++ b/includes/links.md
@@ -16,6 +16,7 @@
 [CustomResourceExt]: https://docs.rs/kube/latest/kube/trait.CustomResourceExt.html
 [CustomResourceDefinition]: https://docs.rs/k8s-openapi/latest/k8s_openapi/apiextensions_apiserver/pkg/apis/apiextensions/v1/struct.CustomResourceDefinition.html
 [Resource]: https://docs.rs/kube/latest/kube/trait.Resource.html
+[ResourceExt]: https://docs.rs/kube/latest/kube/trait.ResourceExt.html
 [ApiResource]: https://docs.rs/kube/latest/kube/core/struct.ApiResource.html
 [ListParams]: https://docs.rs/kube/latest/kube/api/struct.ListParams.html
 [watcher::Config]: https://docs.rs/kube/latest/kube/runtime/watcher/struct.Config.html
@@ -41,6 +42,9 @@
 [discovery]: https://docs.rs/kube/latest/kube/discovery/index.html
 [recommended_kind]: https://docs.rs/kube/latest/kube/discovery/struct.ApiGroup.html#method.recommended_kind
 [merge_crds]: https://docs.rs/kube/latest/kube/core/crd/v1/fn.merge_crds.html
+[shutdown_on_signal]: https://docs.rs/kube/latest/kube/runtime/struct.Controller.html#method.shutdown_on_signal
+[tokio::try_join!]: https://docs.rs/tokio/latest/tokio/macro.try_join.html
+[Infallible]: https://doc.rust-lang.org/std/convert/enum.Infallible.html
 [kube]: https://crates.io/crates/kube
 [kopium]: https://github.com/kube-rs/kopium
 [controller-rs]: https://github.com/kube-rs/controller-rs

--- a/includes/links.md
+++ b/includes/links.md
@@ -44,7 +44,6 @@
 [merge_crds]: https://docs.rs/kube/latest/kube/core/crd/v1/fn.merge_crds.html
 [shutdown_on_signal]: https://docs.rs/kube/latest/kube/runtime/struct.Controller.html#method.shutdown_on_signal
 [tokio::try_join!]: https://docs.rs/tokio/latest/tokio/macro.try_join.html
-[Infallible]: https://doc.rust-lang.org/std/convert/enum.Infallible.html
 [kube]: https://crates.io/crates/kube
 [kopium]: https://github.com/kube-rs/kopium
 [controller-rs]: https://github.com/kube-rs/controller-rs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
     - controllers/optimization.md
     - controllers/security.md
     - controllers/streams.md
+    - controllers/generics.md
     - controllers/internals.md
 
   #- comunity.md


### PR DESCRIPTION
feel like this is another question that pops up a bit so thought i'd take the setup i personally use for labelling and show it as an example in a new advanced chapter in the controller guide.

So far, this only features a way to do generics via `PartialObjectMeta<K>` which is a very particular shortcut, but a very effective one. I am happy to let someone else who has strong opinions on code generics chime in or write other sections.