### PR TITLE
troubleshooting guide

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,44 @@
 
 Problems with [Api] commands failing is often RBAC or naming related and can be identified either in error codes or logs.
 
-### Cross-referencing with kubectl
+See [[observability#adding-logs]] for how to a tracing subscriber set-up so you can get `kube` logs printed.
+
+### Access
+
+Access issues bubble up as an [kube::Error::Api](https://docs.rs/kube/latest/kube/enum.Error.html#variant.Api) where the underlying error code will contain a `403`.
+
+These will show up looking something like this when printed:
+
+```sh
+ErrorResponse { status: "Failure", message: "documents.kube.rs \"samuel\" is forbidden: User \"system:serviceaccount:default:doc-controller\" cannot patch resource \"documents\" in API group \"kube.rs\" in the namespace \"default\"", reason: "Forbidden", code: 403 }
+```
+
+And they should be visible directly (if you are printing your error objects somewhere rather than discarding them), or internally.
+
+
+### Watcher Errors
+
+An infinite [watcher] loop (see [[streams]]) will __retry on all failures__, but access errors are printed (with at least `RUST_LOG=warn` lower)
+
+```sh
+WARN kube_runtime::watcher: watcher error 403: Api(ErrorResponse { status: "Failure", message: "documents.kube.rs is forbidden: User \"system:serviceaccount:default:doc-controller\" cannot watch resource \"documents\" in API group \"kube.rs\" at the cluster scope", reason: "Forbidden", code: 403 })
+```
+
+so either make sure you have some sanity mechanism in place to catch this because a watcher stuck in an access problem will not get any data.
+
+One common solution is to add metrics via [[observability#adding-metrics]] and track that your controller (or similar) always has work to do via periodic requeuing.
+
+Another is to check for certain errors up front before starting an infinite watch stream; say by verifying you can do a naked list first;
+
+```rust
+if let Err(e) = docs.list(&ListParams::default().limit(1)).await {
+    error!("CRD is not queryable; {e:?}. Is the CRD installed?");
+    info!("Installation: cargo run --bin crdgen | kubectl apply -f -");
+    std::process::exit(1);
+}
+```
+
+### Request Inspection
 
 If you are replicating functionality you can use from `kubectl`, then you can verify that what `kube` does is the same as `kubectl`.
 
@@ -16,7 +53,7 @@ curl -v -XPOST -H "X-Stream-Protocol-Version: v4.channel.k8s.io" \
   'https://0.0.0.0:64262/api/v1/namespaces/kube-system/pods/example/exec?command=sh&command=-c&command=for+i+in+%24%28seq+1+3%29%3B+do+date%3B+done&container=example&stdin=true&stdout=true&tty=true'
 ```
 
-This url and query parameters can be cross-referenced in a rust application with log instrumentation (see [[observability#adding-logs]]).
+This url and query parameters can be cross-referenced in the logs from `kube_client`.
 
 A very similar call is here being done [from the `pod_exec` example](https://github.com/kube-rs/kube/blob/12bd223e0a7ef49c4ed0420a169e6c1bc3c1e214/examples/pod_exec.rs#L57-L63), and when running with `RUST_LOG=debug` we can find a "requesting" debug line with the url used:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,31 @@
+# Troubleshooting
+
+## Kubernetes Access
+
+Problems with [Api] commands failing is often RBAC or naming related and can be identified either in error codes or logs.
+
+### Cross-referencing with kubectl
+
+If you are replicating functionality you can use from `kubectl`, then you can verify that what `kube` does is the same as `kubectl`.
+
+Given an [example alpine pod](https://github.com/kube-rs/kube/blob/12bd223e0a7ef49c4ed0420a169e6c1bc3c1e214/examples/pod_exec.rs#L19-L29), we run `exec` on a shell loop, and use `-v=9` to look for a `curl` expression in a large (and abbreviated) amount of debug output to see what we actually tell the apiserver to do:
+
+```sh
+$ kubectl exec example -it -v=9 -- sh -c 'for i in $(seq 1 3); do date; done'
+curl -v -XPOST -H "X-Stream-Protocol-Version: v4.channel.k8s.io" \
+  'https://0.0.0.0:64262/api/v1/namespaces/kube-system/pods/example/exec?command=sh&command=-c&command=for+i+in+%24%28seq+1+3%29%3B+do+date%3B+done&container=example&stdin=true&stdout=true&tty=true'
+```
+
+This url and query parameters can be cross-referenced in a rust application with log instrumentation (see [[observability#adding-logs]]).
+
+A very similar call is here being done [from the `pod_exec` example](https://github.com/kube-rs/kube/blob/12bd223e0a7ef49c4ed0420a169e6c1bc3c1e214/examples/pod_exec.rs#L57-L63), and when running with `RUST_LOG=debug` we can find a "requesting" debug line with the url used:
+
+```sh
+$ RUST_LOG=debug cargo run --example pod_exec
+DEBUG HTTP{http.method=GET http.url=https://0.0.0.0:64262/api/v1/namespaces/kube-system/pods/example/exec?&stdout=true&command=sh&command=-c&command=for+i+in+%24%28seq+1+3%29%3B+do+date%3B+done otel.name="exec" otel.kind="client"}: kube_client::client::builder: requesting
+```
+
+Then we can investigate whether our query parameters matches what is expected (in this case stream differences and tty differences).
+
+--8<-- "includes/abbreviations.md"
+--8<-- "includes/links.md"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,74 +1,12 @@
 # Troubleshooting
 
-Problems with [Api] commands failing is often RBAC or naming related and can be identified either in error codes or logs. Some common problems and solutions are explored herein.
+Problems with [Api] commands failing is often RBAC, misspelled names (used for url construction) and can be usually be identified via error codes and logs. Some common problems and solutions are explored herein.
 
-See [[observability#adding-logs]] for how to setup tracing subscribers to `kube` logs gets printed.
+!!! note "Logs are a prerequisite"
 
-## Access
+    See [[observability#adding-logs]] for how to setup tracing subscribers properly ([env_logger] works also).
 
-Access issues is a result of misconfigured access or lacking [[manifests#RBAC]] and will bubble up as a [kube::Error::Api](https://docs.rs/kube/latest/kube/enum.Error.html#variant.Api) where the underlying error code will contain a `403`.
-
-In print, they look something like this:
-
-```sh
-ErrorResponse { status: "Failure", message: "documents.kube.rs \"samuel\" is forbidden: User \"system:serviceaccount:default:doc-controller\" cannot patch resource \"documents\" in API group \"kube.rs\" in the namespace \"default\"", reason: "Forbidden", code: 403 }
-```
-
-And they should be visible directly provided you are actully printing your error objects somewhere (rather than discarding them).
-
-If you turn up logging to `RUST_LOG=kube=debug` you should also see most errors internally.
-
-### Watcher Errors
-
-A [watcher] will expose [watcher::Error] as the error part of it's `Stream` items. If these errors are discarded, it might lead to a continuously failing and retrying program.
-
-!!! warning "Watcher errors are soft errors"
-
-    A watcher will retry on all failures (including 403s, network failures) because the watcher can recover if external circumstances improve (for instance by an admin tweaking a `Role` object, or the network improving). These errors are therefore often __optimistically ignored__, but they should never be __silently ignored__.
-
-When matching on items from the stream and printing the errors, the errors can look like:
-
-```sh
-WatchFailed(Api(ErrorResponse { status: "Failure", message: "ListOptions.meta.k8s.io \"\" is invalid: resourceVersionMatch: Forbidden: resourceVersionMatch is forbidden for watch", reason: "Invalid", code: 422 }))
-```
-
-If you are not printing the watcher errors yourself, you can get them via logs from `kube_runtime` (available with `RUST_LOG=warn` for the most common errors like RBAC, or `RUST_LOG=kube=debug` for the more obscure errors). It will look something like this:
-
-```sh
-WARN kube_runtime::watcher: watcher error 403: Api(ErrorResponse { status: "Failure", message: "documents.kube.rs is forbidden: User \"system:serviceaccount:default:doc-controller\" cannot watch resource \"documents\" in API group \"kube.rs\" at the cluster scope", reason: "Forbidden", code: 403 })
-```
-
-#### Watcher Error Handling
-
-The __easiest__ error handling setup is to tear down the application on any errors by (say) passing stream errors through a `try_for_each` (ala [pod_watcher](https://github.com/kube-rs/kube/blob/5813ad043e00e7b34de5e22a3fd983419ece2493/examples/pod_watcher.rs#L26-L33)) or a `try_next` loop (ala [event_watcher](https://github.com/kube-rs/kube/blob/5813ad043e00e7b34de5e22a3fd983419ece2493/examples/event_watcher.rs#L39-L43)).
-
-!!! note "Crashing in-cluster"
-
-    If you are deployed in-cluster, don't be afraid to exit early on errors you don't expect. Exits are easier to handle than a badly running app in a confusing state. By crashing, you get [retry with backoff](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy) for free, plus you often get alerts such as [KubePodCrashLooping](https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping/) triggering (without instrumentation needed).
-
-While easy, early exits is not the best solution;
-
-- __Locally__, having a CLI abruptly exit is a bad user experience.
-- __In-cluster__, frequent restarts of a large app with many spurious non-fatal condition can mask underlying problems.
-
-For controllers with multiple watchers, [[observability#Adding Metrics]] is customary, so that you can alert on percentage error rates over a time span.
-
-It is also common to check for **blocker errors** up-front before starting an infinite watch stream;
-
-1. did you install the crd before trying to start a watcher? do a naked list first as a sanity:
-
-```rust
-if let Err(e) = docs.list(&ListParams::default().limit(1)).await {
-    error!("CRD is not queryable; {e:?}. Is the CRD installed?");
-    info!("Installation: cargo run --bin crdgen | kubectl apply -f -");
-    std::process::exit(1);
-}
-watcher(docs, conf).try_for_each(|_| future::ready(Ok(()))).await?;
-```
-
-This is a particularly common error case since CRD installation is often managed out-of-band with the application and thus often neglected.
-
-### Request Inspection
+## Request Inspection
 
 If you are replicating `kubectl` behaviour, then you can cross-reference with logs.
 
@@ -91,6 +29,73 @@ DEBUG HTTP{http.method=GET http.url=https://0.0.0.0:64262/api/v1/namespaces/kube
 ```
 
 Then we can investigate whether our query parameters matches what is expected (in this case stream differences and tty differences).
+
+## Access
+
+Access issues is a result of misconfigured access or lacking [[manifests#RBAC]] and will bubble up as a [kube::Error::Api](https://docs.rs/kube/latest/kube/enum.Error.html#variant.Api) where the underlying error code will contain a `403`.
+
+In print, they look something like this:
+
+```sh
+ErrorResponse { status: "Failure", message: "documents.kube.rs \"samuel\" is forbidden: User \"system:serviceaccount:default:doc-controller\" cannot patch resource \"documents\" in API group \"kube.rs\" in the namespace \"default\"", reason: "Forbidden", code: 403 }
+```
+
+And they should be visible directly provided you are actully printing your error objects somewhere (rather than discarding them).
+
+If you turn up logging to `RUST_LOG=kube=debug` you should also see most errors internally.
+
+## Watcher Errors
+
+A [watcher] will expose [watcher::Error] as the error part of it's `Stream` items. If these errors are discarded, it might lead to a continuously failing and retrying program.
+
+!!! warning "Watcher errors are soft errors"
+
+    A watcher will retry on all failures (including 403s, network failures) because the watcher can recover if external circumstances improve (for instance by an admin tweaking a `Role` object, or the network improving). These errors are therefore often __optimistically ignored__, but they should never be __silently ignored__.
+
+When matching on items from the stream and printing the errors, the errors can look like:
+
+```sh
+WatchFailed(Api(ErrorResponse { status: "Failure", message: "ListOptions.meta.k8s.io \"\" is invalid: resourceVersionMatch: Forbidden: resourceVersionMatch is forbidden for watch", reason: "Invalid", code: 422 }))
+```
+
+If you are not printing the watcher errors yourself, you can get them via logs from `kube_runtime` (available with `RUST_LOG=warn` for the most common errors like RBAC, or `RUST_LOG=kube=debug` for the more obscure errors). It will look something like this:
+
+```sh
+WARN kube_runtime::watcher: watcher error 403: Api(ErrorResponse { status: "Failure", message: "documents.kube.rs is forbidden: User \"system:serviceaccount:default:doc-controller\" cannot watch resource \"documents\" in API group \"kube.rs\" at the cluster scope", reason: "Forbidden", code: 403 })
+```
+
+## Stream Errors
+
+Because of the soft-error policy on stream errors, it's useful to consider what to do with errors in general from infinite streams.
+
+The __easiest__ error handling setup is to tear down the application on any errors by (say) passing stream errors through a `try_for_each` (ala [pod_watcher](https://github.com/kube-rs/kube/blob/5813ad043e00e7b34de5e22a3fd983419ece2493/examples/pod_watcher.rs#L26-L33)) or a `try_next` loop (ala [event_watcher](https://github.com/kube-rs/kube/blob/5813ad043e00e7b34de5e22a3fd983419ece2493/examples/event_watcher.rs#L39-L43)).
+
+!!! note "Crashing in-cluster"
+
+    If you are deployed in-cluster, don't be afraid to exit(1)/crash early on errors you don't expect. Exits are easier to handle than a badly running app in a confusing state. By crashing, you get [retry with backoff](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy) for free, plus you often get alerts such as [KubePodCrashLooping](https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping/) triggering (without instrumentation needed).
+
+While easy, early exits is not the best solution;
+
+- __Locally__, having a CLI abruptly exit is a bad user experience.
+- __In-cluster__, frequent restarts of a large app with many spurious non-fatal condition can mask underlying problems.
+- early exits throw cancel-safety and state transaction concerns out the window
+
+For controllers with multiple watchers, [[observability#Adding Metrics]] is instead customary, so that you can alert on percentage error rates over a time span (telling the operator to go look at logs for why).
+
+It is also common to check for **blocker errors** up-front before starting an infinite watch stream;
+
+1. did you install the crd before trying to start a watcher? do a naked list first as a sanity:
+
+```rust
+if let Err(e) = docs.list(&ListParams::default().limit(1)).await {
+    error!("CRD is not queryable; {e:?}. Is the CRD installed?");
+    info!("Installation: cargo run --bin crdgen | kubectl apply -f -");
+    std::process::exit(1);
+}
+watcher(docs, conf).try_for_each(|_| future::ready(Ok(()))).await?;
+```
+
+This is a particularly common error case since CRD installation is often managed out-of-band with the application and thus often neglected.
 
 --8<-- "includes/abbreviations.md"
 --8<-- "includes/links.md"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,14 +1,12 @@
 # Troubleshooting
 
-## Kubernetes Access
-
-Problems with [Api] commands failing is often RBAC or naming related and can be identified either in error codes or logs.
+Problems with [Api] commands failing is often RBAC or naming related and can be identified either in error codes or logs. Some common problems are explored herein.
 
 See [[observability#adding-logs]] for how to a tracing subscriber set-up so you can get `kube` logs printed.
 
-### Access
+## Access
 
-Access issues bubble up as an [kube::Error::Api](https://docs.rs/kube/latest/kube/enum.Error.html#variant.Api) where the underlying error code will contain a `403`.
+Access issues is a result of misconfigured or lacking [[manifests#RBAC]] and will bubble up as a [kube::Error::Api](https://docs.rs/kube/latest/kube/enum.Error.html#variant.Api) where the underlying error code will contain a `403`.
 
 These will show up looking something like this when printed:
 
@@ -21,17 +19,34 @@ And they should be visible directly (if you are printing your error objects some
 
 ### Watcher Errors
 
-An infinite [watcher] loop (see [[streams]]) will __retry on all failures__, but access errors are printed (with at least `RUST_LOG=warn` lower)
+A [watcher] will expose [watcher::Error] as the error part of it's `Stream` items. If these errors are discarded, it might lead to a continuously failing and retrying program.
+
+!!! warning "Watcher errors are soft errors"
+
+    A watcher will retry on all failures (including 403s, network failures) because the watcher can recover if external circumstances improve (for instance by an admin tweaking a `Role` object, or the network improving). These errors are therefore often ignored optimistically, but they should __never be silently ignored__.
+
+When matching on items from the stream and printing the errors, the errors can look like:
+
+```sh
+WatchFailed(Api(ErrorResponse { status: "Failure", message: "ListOptions.meta.k8s.io \"\" is invalid: resourceVersionMatch: Forbidden: resourceVersionMatch is forbidden for watch", reason: "Invalid", code: 422 }))
+```
+
+If you are not printing the watcher errors yourself, you can get them via logs from `kube_runtime` (available with `RUST_LOG=warn` for the most common errors like RBAC, or `RUST_LOG=kube=debug` for the more obscure errors). It will look something like this:
 
 ```sh
 WARN kube_runtime::watcher: watcher error 403: Api(ErrorResponse { status: "Failure", message: "documents.kube.rs is forbidden: User \"system:serviceaccount:default:doc-controller\" cannot watch resource \"documents\" in API group \"kube.rs\" at the cluster scope", reason: "Forbidden", code: 403 })
 ```
 
-so either make sure you have some sanity mechanism in place to catch this because a watcher stuck in an access problem will not get any data.
+The easiest error handling is to tear down the application on any errors by i.e. passing stream errors through a `try_for_each` (ala [pod_watcher](https://github.com/kube-rs/kube/blob/5813ad043e00e7b34de5e22a3fd983419ece2493/examples/pod_watcher.rs#L26-L33)). This will usually let you know something is broken by crashing. Usually this either annoys the user, or it triggers the common [KubePodCrashLooping](https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping/) alert if you are deployed in-cluster. In both cases, this is an inelegant way of handling errors since it means you will also restart the full application on spurious network issues.
 
-One common solution is to add metrics via [[observability#adding-metrics]] and track that your controller (or similar) always has work to do via periodic requeuing.
+More error handling solutions is to try to handle errors for a while, but report them up to your environment. When deployed in-cluster, [[obervability#adding-metrics]] is the normal path, so you can alert on a higher than normal error rates (if they persist).
 
-Another is to check for certain errors up front before starting an infinite watch stream; say by verifying you can do a naked list first;
+
+<!-- TODO: will move this to another productionising document later i think
+
+Another is to check for the most common error up front before starting an infinite watch stream;
+
+1. did you install the crd before trying to start a watcher? do a naked list first and exit if not:
 
 ```rust
 if let Err(e) = docs.list(&ListParams::default().limit(1)).await {
@@ -40,16 +55,18 @@ if let Err(e) = docs.list(&ListParams::default().limit(1)).await {
     std::process::exit(1);
 }
 ```
+-->
 
 ### Request Inspection
 
-If you are replicating functionality you can use from `kubectl`, then you can verify that what `kube` does is the same as `kubectl`.
+If you are replicating `kubectl` behaviour, then you can cross-reference with logs.
 
-Given an [example alpine pod](https://github.com/kube-rs/kube/blob/12bd223e0a7ef49c4ed0420a169e6c1bc3c1e214/examples/pod_exec.rs#L19-L29), we run `exec` on a shell loop, and use `-v=9` to look for a `curl` expression in a large (and abbreviated) amount of debug output to see what we actually tell the apiserver to do:
+Given an [example alpine pod](https://github.com/kube-rs/kube/blob/12bd223e0a7ef49c4ed0420a169e6c1bc3c1e214/examples/pod_exec.rs#L19-L29), we will run `exec` on a shell loop, and use `-v=9` to look for a `curl` expression in a large (and abbreviated) amount of debug output to see what we actually tell the apiserver to do:
 
 ```sh
 $ kubectl exec example -it -v=9 -- sh -c 'for i in $(seq 1 3); do date; done'
-curl -v -XPOST -H "X-Stream-Protocol-Version: v4.channel.k8s.io" \
+
+round_trippers.go:466] curl -v -XPOST -H "X-Stream-Protocol-Version: v4.channel.k8s.io" \
   'https://0.0.0.0:64262/api/v1/namespaces/kube-system/pods/example/exec?command=sh&command=-c&command=for+i+in+%24%28seq+1+3%29%3B+do+date%3B+done&container=example&stdin=true&stdout=true&tty=true'
 ```
 

--- a/includes/links.md
+++ b/includes/links.md
@@ -20,6 +20,7 @@
 [ApiResource]: https://docs.rs/kube/latest/kube/core/struct.ApiResource.html
 [ListParams]: https://docs.rs/kube/latest/kube/api/struct.ListParams.html
 [watcher::Config]: https://docs.rs/kube/latest/kube/runtime/watcher/struct.Config.html
+[watcher::Error]: https://docs.rs/kube/latest/kube/runtime/watcher/enum.Error.html
 [controller::Config]: https://docs.rs/kube/latest/kube/runtime/controller/struct.Config.html
 [any_semantic]: https://docs.rs/kube/latest/kube/runtime/watcher/struct.Config.html#method.any_semantic
 [Object]: https://docs.rs/kube/latest/kube/core/struct.Object.html

--- a/includes/links.md
+++ b/includes/links.md
@@ -95,3 +95,4 @@
 [Server-Side Apply]: https://kubernetes.io/docs/reference/using-api/server-side-apply/
 [k3d]: https://k3d.io/
 [JsonSchema]: https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html
+[env_logger]: https://docs.rs/env_logger/latest/env_logger/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
   - kubernetes-version.md
   - stability.md
   - architecture.md
+  - troubleshooting.md
   - adopters.md
   - guides.md
   - upgrading.md


### PR DESCRIPTION
a guide on how to do log based debugging (and gently steering them away from it where possible)

- request inspection (with `RUST_LOG` vis-a-vis `kubectl`)
- access error identification
- soft errors of `watcher` and how to deal with them in general