### PR TITLE
add Aptakube as adopter

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -40,6 +40,7 @@
 - [Kong](https://konghq.com)
 - [MetalBear](https://metalbear.co)
 - [Tembo](https://tembo.io/)
+- [Aptakube](https://aptakube.com/)
 
 If you're using `kube-rs` in production and are not on this list, please [submit a pull request](https://github.com/kube-rs/website/edit/main/docs/adopters.md)!
 


### PR DESCRIPTION
Hi, I'm an indie dev working on Aptakube and I've made some minor contributions to kube-rs last year
I only see big names on this list, are indie companied allowed as well? :)


