### PR TITLE
Add @mateiidavid to maintainers.md

### DIFF
--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -5,6 +5,7 @@ The Kube-rs maintainers are:
 * Eirik Albrigtsen <sszynrae@gmail.com> [@clux](https://github.com/clux)
 * Natalie Klestrup Röijezon <nat@nullable.se> [@nightkr](https://github.com/nightkr)
 * Kaz Yoshihara <kazk.dev@gmail.com> [@kazk](https://github.com/kazk)
+* Matei David <dev.matei@pm.me> [@mateiidavid](https://github.com/mateiidavid)
 
 ## Emeriti
 


### PR DESCRIPTION
Opening up a PR to propose and socialise the idea of being granted more responsibilities within the kube-rs project. Before opening up the PR, @clux and I had a discussion on this topic during this week's project sync meeting (25th April).