### PR TITLE
Rename references flattened/unflattened streams

### DIFF
--- a/docs/controllers/streams.md
+++ b/docs/controllers/streams.md
@@ -66,7 +66,7 @@ But note this changes the stream signature slightly; returning a wrapped [Partia
 - **decoded stream** :: a stream that's been through [EventDecode] via one of `WatchStreamExt::touched_objects`, `WatchStreamExt::applied_objects`
 - **event stream** :: a raw [watcher] stream producing [watcher::Event] objects
 
-The significant difference between them is that the **user** and the [Controller] generally wants to interact with an **decoded stream**, but a [reflector] needs an **event stream** to be able to safely replace its contents.
+The significant difference between them is that the **user** and the [Controller] generally wants to interact with a **decoded stream**, but a [reflector] needs an **event stream** to be able to safely replace its contents.
 
 ### WatchStreamExt
 The [WatchStreamExt] trait is a `Stream` extension trait (ala [StreamExt]) with Kubernetes specific helper methods that can be chained onto a watcher stream;
@@ -138,7 +138,7 @@ Controller::for_stream(main_stream, reader)
     .watches_stream(watched_custom_stream, cfg)
 ```
 
-where the various stream variables would be created from either [watcher], or [metadata_watcher] with some filters applied.
+where the various stream variables would be created from either [watcher], or [metadata_watcher] with a decoder applied.
 
 !!! warning "The controller streams interface is unstable"
 

--- a/docs/controllers/streams.md
+++ b/docs/controllers/streams.md
@@ -63,10 +63,10 @@ But note this changes the stream signature slightly; returning a wrapped [Partia
 ### Terminology
 
 - **watcher stream** :: a stream that is started by one of the watcher [[#stream-entrypoints]]
-- **unpacked stream** :: a stream that's been through [EventFilter] via one of `WatchStreamExt::touched_objects`, `WatchStreamExt::applied_objects`
+- **decoded stream** :: a stream that's been through [EventDecode] via one of `WatchStreamExt::touched_objects`, `WatchStreamExt::applied_objects`
 - **event stream** :: a raw [watcher] stream producing [watcher::Event] objects
 
-The significant difference between them is that the **user** and the [Controller] generally wants to interact with an **unpacked stream**, but a [reflector] needs an **event stream** to be able to safely replace its contents.
+The significant difference between them is that the **user** and the [Controller] generally wants to interact with an **decoded stream**, but a [reflector] needs an **event stream** to be able to safely replace its contents.
 
 ### WatchStreamExt
 The [WatchStreamExt] trait is a `Stream` extension trait (ala [StreamExt]) with Kubernetes specific helper methods that can be chained onto a watcher stream;
@@ -82,7 +82,7 @@ watcher(api, watcher::Config::default())
 These methods can require one of:
 
 - **event stream** (where the input stream `Item = Result<Event<K>, ...>`
-- **unpacked stream** (where `Item = Result<K, ...>`, the last ones in the chain)
+- **decoded stream** (where `Item = Result<K, ...>`, the last ones in the chain)
 
 It is impossible to apply them in an incompatible configuration.
 
@@ -90,7 +90,7 @@ It is impossible to apply them in an incompatible configuration.
 It is possible to modify or filter the input streams before passing them on. This can usually either done to limit data in memory by pruning, or to filter events to a downstream controller so that it either triggers less frequently.
 
 ### Predicates
-Using [predicates], we can **filter out** events from a stream where the **last value** of a particular property is **unchanged**. This is done internally by storing hashes of the given property(ies), and can be chained onto an **unpacked** stream:
+Using [predicates], we can **filter out** events from a stream where the **last value** of a particular property is **unchanged**. This is done internally by storing hashes of the given property(ies), and can be chained onto an **decoded** stream:
 
 ```rust
 let api: Api<Deployment> = Api::all(client);
@@ -168,7 +168,7 @@ Controller::new(api, Config::default())
 To configure one of the input streams manually you need to:
 
 1. create a watcher stream with backoff
-2. unpack the stream
+2. decode the stream
 3. call the stream-equivalent `Controller` interface
 
 Note that the `Controller` will poll all the passed (or implicitly created) watcher streams as a whole when you poll the output stream from the controller.

--- a/docs/controllers/streams.md
+++ b/docs/controllers/streams.md
@@ -63,10 +63,10 @@ But note this changes the stream signature slightly; returning a wrapped [Partia
 ### Terminology
 
 - **watcher stream** :: a stream that is started by one of the watcher [[#stream-entrypoints]]
-- **flattened stream** :: a stream that's been through [EventFlatten] via one of `WatchStreamExt::touched_objects`, `WatchStreamExt::applied_objects`
-- **event stream** :: a raw [watcher] stream producing un-flattened [watcher::Event] objects
+- **unpacked stream** :: a stream that's been through [EventFilter] via one of `WatchStreamExt::touched_objects`, `WatchStreamExt::applied_objects`
+- **event stream** :: a raw [watcher] stream producing [watcher::Event] objects
 
-The significant difference between them is that the **user** and the [Controller] generally wants to interact with a **flattened stream**, but a [reflector] needs an **event stream** to be able to safely replace its contents.
+The significant difference between them is that the **user** and the [Controller] generally wants to interact with an **unpacked stream**, but a [reflector] needs an **event stream** to be able to safely replace its contents.
 
 ### WatchStreamExt
 The [WatchStreamExt] trait is a `Stream` extension trait (ala [StreamExt]) with Kubernetes specific helper methods that can be chained onto a watcher stream;
@@ -82,7 +82,7 @@ watcher(api, watcher::Config::default())
 These methods can require one of:
 
 - **event stream** (where the input stream `Item = Result<Event<K>, ...>`
-- **flattened stream** (where `Item = Result<K, ...>`, the last ones in the chain)
+- **unpacked stream** (where `Item = Result<K, ...>`, the last ones in the chain)
 
 It is impossible to apply them in an incompatible configuration.
 
@@ -90,7 +90,7 @@ It is impossible to apply them in an incompatible configuration.
 It is possible to modify or filter the input streams before passing them on. This can usually either done to limit data in memory by pruning, or to filter events to a downstream controller so that it either triggers less frequently.
 
 ### Predicates
-Using [predicates], we can **filter out** events from a stream where the **last value** of a particular property is **unchanged**. This is done internally by storing hashes of the given property(ies), and can be chained onto a **flattened** stream:
+Using [predicates], we can **filter out** events from a stream where the **last value** of a particular property is **unchanged**. This is done internally by storing hashes of the given property(ies), and can be chained onto an **unpacked** stream:
 
 ```rust
 let api: Api<Deployment> = Api::all(client);
@@ -138,7 +138,7 @@ Controller::for_stream(main_stream, reader)
     .watches_stream(watched_custom_stream, cfg)
 ```
 
-where the various stream variables would be created from either [watcher], or [metadata_watcher] with some filters/flatteners applied.
+where the various stream variables would be created from either [watcher], or [metadata_watcher] with some filters applied.
 
 !!! warning "The controller streams interface is unstable"
 
@@ -168,7 +168,7 @@ Controller::new(api, Config::default())
 To configure one of the input streams manually you need to:
 
 1. create a watcher stream with backoff
-2. flatten the stream
+2. unpack the stream
 3. call the stream-equivalent `Controller` interface
 
 Note that the `Controller` will poll all the passed (or implicitly created) watcher streams as a whole when you poll the output stream from the controller.

--- a/includes/links.md
+++ b/includes/links.md
@@ -36,7 +36,7 @@
 [watcher]: https://docs.rs/kube/latest/kube/runtime/fn.watcher.html
 [metadata_watcher]: https://docs.rs/kube/latest/kube/runtime/fn.metadata_watcher.html
 [watcher::Event]: https://docs.rs/kube/latest/kube/runtime/watcher/enum.Event.html
-[EventFlatten]: https://docs.rs/kube/latest/kube/runtime/utils/struct.EventFlatten.html
+[EventDecode]: https://docs.rs/kube/latest/kube/runtime/utils/struct.EventDecode.html
 [Recorder]: https://docs.rs/kube/latest/kube/runtime/events/struct.Recorder.html
 [Event::modify]: https://docs.rs/kube/latest/kube/runtime/watcher/enum.Event.html#method.modify
 [StreamExt]: https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html


### PR DESCRIPTION
generally referring to them as unpacked now (as they get filtered and unpacked of the Event enum)

for 0.96 after https://github.com/kube-rs/kube/pull/1520 releases