### PR TITLE
Update metadata watcher sections to reflect inference

### DIFF
--- a/docs/controllers/generics.md
+++ b/docs/controllers/generics.md
@@ -63,11 +63,11 @@ where
     let kind = K::kind(&()).to_string();
     tracing::info!("Starting controller for {kind}");
 
-    let api = Api::<K>::all(client.clone());
+    let api = Api::<PartialObjectMeta<K>>::all(client.clone());
     let (reader, writer) = reflector::store();
 
     // controller main stream from metadata_watcher
-    let stream = metadata_watcher(api, watcher::Config::default())
+    let stream = watcher(api, watcher::Config::default())
         .default_backoff()
         .modify(|x| {
             x.managed_fields_mut().clear(); // ResourceExt pruning
@@ -87,7 +87,8 @@ where
 
 This example assumes no [[relations]] between the main controller [[object]], so that each controller can be started in isolation without worrying about inefficiencies in [[streams]] usage.
 
-It uses [metadata_watcher] to provide a consistent input stream of `PartialObjectMeta<K>` with pruning ([[optimization#pruning-fields]]) and [Store] management through [WatchStreamExt].
+It uses pruning ([[optimization#pruning-fields]]) and [Store] management through [WatchStreamExt], and uses the `PartialObjectMeta<K>` wrapper around `K` ensures kube uses the cheaper [metadata Api] for querying.
+
 
 We can start and control the lifecycle of all the controllers with a [tokio::join!]:
 

--- a/docs/controllers/streams.md
+++ b/docs/controllers/streams.md
@@ -39,25 +39,25 @@ The above example will run continuously until the end of the program. Note that 
 
 ### Metadata Watcher
 
-A [metadata_watcher] is a [watcher] analogue that using the **metadata api** that **only** returns [TypeMeta] (`.api_version` + `.kind`) + [ObjectMeta] (`.metadata`).
+A metadata watcher is a [watcher] using the [metadata api] that **only** returns [TypeMeta] (`.api_version` + `.kind`) + [ObjectMeta] (`.metadata`). (Previously this was known as [metadata_watcher] but users no longer have to select this manually).
 
-This can generally be used as a **drop-in replacement** for [watcher] provided you do not need data in `.spec` or `.status`.
+This is used whenever you use [watcher] with an [Api] using tthe [PartialObjectMeta] around a resource `K` (e.g. `Api::<PartialObjectMeta<K>>`) as this makes it explicit that you do not need the data in `.spec` or `.status`.
 
 This means less IO, and less memory usage (especially if you are using it with a [reflector]). See the **[[optimization]] chapter** for details.
 
-You can generally **replace** `watcher` with `metadata_watcher` in the examples above as:
+You can generally **replace** your resource `K` with `PartialObjectMeta<K>` in the above examples for the `Api` before passing the `Api` to `watcher`:
 
 ```diff
 # General change:
--let stream =          watcher(api, cfg).applied_objects();
-+let stream = metadata_watcher(api, cfg).applied_objects();
+-let api = Api::<Pod>::default_namespaced(client);
++let api = Api::<PartialObjectMeta<Pod>>::default_namespaced(client);
 
-# Same change inside a reflector:
--let stream = reflector(writer,          watcher(api, cfg)).applied_objects();
-+let stream = reflector(writer, metadata_watcher(api, cfg)).applied_objects();
+# generic setup
+-let api = Api::<K>::all(ctx.client.clone());
++let api = Api::<PartialObjectMeta<K>>::all(ctx.client.clone());
 ```
 
-But note this changes the stream signature slightly; returning a wrapped [PartialObjectMeta].
+But note that this signature forces the use of the metadata api for all queries using this `api`.
 
 ## Watcher Streams
 ### Terminology

--- a/includes/links.md
+++ b/includes/links.md
@@ -8,6 +8,7 @@
 [Controller::reconcile_on]: https://docs.rs/kube/latest/kube/runtime/struct.Controller.html#method.reconcile_on
 [Controller::run]: https://docs.rs/kube/latest/kube/runtime/struct.Controller.html#method.run
 [ReconcileReason]: https://docs.rs/kube/latest/kube/runtime/controller/enum.ReconcileReason.html
+[metadata Api][https://docs.rs/kube/latest/kube/api/struct.Api.html?search=Api%20_metadata]
 [ObjectRef]: https://docs.rs/kube/latest/kube/runtime/reflector/struct.ObjectRef.html
 [applier]: https://docs.rs/kube/latest/kube/runtime/fn.applier.html
 [Api]: https://docs.rs/kube/latest/kube/struct.Api.html


### PR DESCRIPTION
Reflects inference logic now built into `watcher` for 4.0, users no longer are expected to pick `metadata_watcher` to use the metadata api, but rather make the type explicit via `PartialObjectMeta`.