### PR TITLE
includes/links: fix link to metadata API

### DIFF
--- a/includes/links.md
+++ b/includes/links.md
@@ -8,7 +8,7 @@
 [Controller::reconcile_on]: https://docs.rs/kube/latest/kube/runtime/struct.Controller.html#method.reconcile_on
 [Controller::run]: https://docs.rs/kube/latest/kube/runtime/struct.Controller.html#method.run
 [ReconcileReason]: https://docs.rs/kube/latest/kube/runtime/controller/enum.ReconcileReason.html
-[metadata Api][https://docs.rs/kube/latest/kube/api/struct.Api.html?search=Api%20_metadata]
+[metadata API]: https://docs.rs/kube/latest/kube/api/struct.Api.html?search=Api%20_metadata
 [ObjectRef]: https://docs.rs/kube/latest/kube/runtime/reflector/struct.ObjectRef.html
 [applier]: https://docs.rs/kube/latest/kube/runtime/fn.applier.html
 [Api]: https://docs.rs/kube/latest/kube/struct.Api.html


### PR DESCRIPTION
While at it, capitalize Api -> API.